### PR TITLE
Update UI background colors

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -94,7 +94,7 @@ function App() {
   );
 
   return (
-    <div className="flex h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 text-gray-300 font-mono overflow-hidden">
+    <div className="flex h-screen bg-[#121212] text-gray-200 font-mono overflow-hidden">
       {/* Main Content Area */}
       <div className="flex-1 flex flex-col min-w-0">
         <Header activeTab={activeTab} onTabChange={handleTabChange} />

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -148,7 +148,7 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
                   </div>
                 </div>
                 
-                <div className={`flex items-center mt-1 text-xs text-gray-500 ${isUser ? 'justify-end mr-4' : 'ml-4'}`}>
+                <div className={`flex items-center mt-1 text-xs text-gray-400 ${isUser ? 'justify-end mr-4' : 'ml-4'}`}>
                   <Clock className="w-3 h-3 mr-1" />
                   {formatTime(item.timestamp)}
                 </div>
@@ -167,7 +167,7 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
                   <div className="w-2 h-2 bg-blue-400 rounded-full animate-bounce" style={{ animationDelay: '0.1s' }} />
                   <div className="w-2 h-2 bg-blue-400 rounded-full animate-bounce" style={{ animationDelay: '0.2s' }} />
                 </div>
-                <span className="text-sm text-gray-300">AI is analyzing...</span>
+                <span className="text-sm text-gray-200">AI is analyzing...</span>
               </div>
             </div>
           </div>
@@ -186,7 +186,7 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
                   key={i}
                   onClick={() => setUserInput(prompt)}
                   disabled={isLoading}
-                  className="px-3 py-1 bg-slate-700/50 hover:bg-slate-600/50 text-xs text-gray-300 hover:text-white rounded-full transition-all duration-200 border border-slate-600/50 hover:border-slate-500/50"
+                  className="px-3 py-1 bg-slate-700/50 hover:bg-slate-600/50 text-xs text-gray-200 hover:text-white rounded-full transition-all duration-200 border border-slate-600/50 hover:border-slate-500/50"
                 >
                   {prompt}
                 </button>

--- a/src/components/InteractionLogger.tsx
+++ b/src/components/InteractionLogger.tsx
@@ -236,7 +236,7 @@ export const InteractionLogger: React.FC<InteractionLoggerProps> = ({
                 <div className="space-y-3">
                   {Object.entries(analytics.tabUsageDistribution).map(([tab, count]) => (
                     <div key={tab} className="flex items-center justify-between">
-                      <span className="text-gray-300 capitalize">{tab}</span>
+                      <span className="text-gray-200 capitalize">{tab}</span>
                       <div className="flex items-center space-x-2">
                         <div className="w-32 bg-slate-700 rounded-full h-2">
                           <div
@@ -293,12 +293,12 @@ export const InteractionLogger: React.FC<InteractionLoggerProps> = ({
                         </span>
                       </div>
                       {interaction.data.message && (
-                        <div className="text-xs text-gray-300 truncate">
+                        <div className="text-xs text-gray-200 truncate">
                           Message: "{interaction.data.message}"
                         </div>
                       )}
                       {interaction.data.fromTab && interaction.data.toTab && (
-                        <div className="text-xs text-gray-300">
+                        <div className="text-xs text-gray-200">
                           Tab: {interaction.data.fromTab} → {interaction.data.toTab}
                         </div>
                       )}

--- a/src/components/MainContent.tsx
+++ b/src/components/MainContent.tsx
@@ -83,7 +83,7 @@ export const MainContent: React.FC<MainContentProps> = ({
   };
 
   return (
-    <main className="flex-1 overflow-y-auto p-6 bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900">
+    <main className="flex-1 overflow-y-auto p-6 bg-[#121212]">
       <div className="max-w-7xl mx-auto">
         <div className="mb-8">
           <h2 className="text-3xl font-bold text-white mb-2 leading-tight">

--- a/src/components/ScenarioPhases.tsx
+++ b/src/components/ScenarioPhases.tsx
@@ -41,7 +41,7 @@ export const ScenarioPhases: React.FC<ScenarioPhasesProps> = ({ phases }) => {
                       flex items-start p-3 rounded-lg transition-all duration-200
                       ${isXAIActivation 
                         ? 'bg-amber-500/20 border border-amber-500/50 text-amber-200' 
-                        : 'bg-slate-800/50 hover:bg-slate-800/70 text-gray-300'
+                        : 'bg-slate-800/50 hover:bg-slate-800/70 text-gray-200'
                       }
                     `}
                   >

--- a/src/components/tabs/InsightTab.tsx
+++ b/src/components/tabs/InsightTab.tsx
@@ -28,7 +28,7 @@ export const InsightTab: React.FC<InsightTabProps> = ({
             Highlights
           </h3>
         </div>
-        <p className="text-gray-300 leading-relaxed whitespace-pre-wrap">
+        <p className="text-gray-200 leading-relaxed whitespace-pre-wrap">
           {explanation.insight?.text}
         </p>
       </VisualCard>

--- a/src/components/tabs/ProjectionTab.tsx
+++ b/src/components/tabs/ProjectionTab.tsx
@@ -24,7 +24,7 @@ export const ProjectionTab: React.FC<ProjectionTabProps> = ({
             Highlights
           </h3>
         </div>
-        <p className="text-gray-300 leading-relaxed whitespace-pre-wrap">
+        <p className="text-gray-200 leading-relaxed whitespace-pre-wrap">
           {explanation.projection?.text}
         </p>
       </VisualCard>

--- a/src/components/tabs/ReasoningTab.tsx
+++ b/src/components/tabs/ReasoningTab.tsx
@@ -27,7 +27,7 @@ export const ReasoningTab: React.FC<ReasoningTabProps> = ({
               Highlights
             </h3>
           </div>
-          <p className="text-gray-300 leading-relaxed whitespace-pre-wrap">
+          <p className="text-gray-200 leading-relaxed whitespace-pre-wrap">
             {explanation.reasoning?.text}
           </p>
         </VisualCard>

--- a/src/components/visualizations/AlternativeOutcomes.tsx
+++ b/src/components/visualizations/AlternativeOutcomes.tsx
@@ -77,7 +77,7 @@ export const AlternativeOutcomes: React.FC<AlternativeOutcomesProps> = ({
               </h4>
             </div>
             
-            <p className="text-sm text-gray-400 leading-relaxed group-hover:text-gray-300 transition-colors">
+            <p className="text-sm text-gray-200 leading-relaxed group-hover:text-gray-100 transition-colors">
               {alt.details}
             </p>
           </div>

--- a/src/components/visualizations/COAComparison.tsx
+++ b/src/components/visualizations/COAComparison.tsx
@@ -67,7 +67,7 @@ export const COAComparison: React.FC<COAComparisonProps> = ({
               </div>
             </div>
             
-            <p className="text-xs text-gray-300 mb-4 leading-relaxed">
+            <p className="text-xs text-gray-200 mb-4 leading-relaxed">
               {coa.summary}
             </p>
             

--- a/src/components/visualizations/DAGVisual.tsx
+++ b/src/components/visualizations/DAGVisual.tsx
@@ -241,7 +241,7 @@ export const DAGVisual: React.FC<DAGVisualProps> = ({
                     <p className="mb-1">{nodeInfo[node.id]?.desc}</p>
                     <p className="text-gray-400 mb-1">{nodeInfo[node.id]?.why}</p>
                     {nodeInfo[node.id]?.whatIf && (
-                      <p className="text-gray-500 italic">What if: {nodeInfo[node.id]?.whatIf}</p>
+                      <p className="text-gray-400 italic">What if: {nodeInfo[node.id]?.whatIf}</p>
                     )}
                   </div>
                 )}

--- a/src/components/visualizations/SHAPVisual.tsx
+++ b/src/components/visualizations/SHAPVisual.tsx
@@ -105,7 +105,7 @@ export const SHAPVisual: React.FC<SHAPVisualProps> = ({
                 onClick={() => handleFeatureClick(feature)}
               >
                 <div className="flex items-center justify-between mb-2">
-                  <span className="text-sm font-medium text-gray-300 group-hover:text-white transition-colors">
+                  <span className="text-sm font-medium text-gray-200 group-hover:text-white transition-colors">
                     {feature}
                   </span>
                   <div className="flex items-center">
@@ -141,9 +141,9 @@ export const SHAPVisual: React.FC<SHAPVisualProps> = ({
       {active && (
         <div className="mt-6 p-4 rounded-lg bg-slate-800/70 border border-slate-600/50 text-sm space-y-1">
           <p className="text-teal-300 font-semibold">{active}</p>
-          <p className="text-gray-300">{featureMeta[active]?.desc}</p>
+          <p className="text-gray-200">{featureMeta[active]?.desc}</p>
           <p className="text-gray-400 text-xs">{featureMeta[active]?.why}</p>
-          <p className="text-gray-500 text-xs">Importance score: {shapData[active]?.toFixed(2)}</p>
+          <p className="text-gray-400 text-xs">Importance score: {shapData[active]?.toFixed(2)}</p>
         </div>
       )}
     </VisualCard>


### PR DESCRIPTION
## Summary
- use a solid dark background for the root layout
- adjust main content background
- standardize body text to `text-gray-200`
- use `text-gray-400` for labels and timestamps

## Testing
- `npm run lint` *(fails: parsing errors and unused vars)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_688905ebe1f88328952998c5e16d4bb9