### PR TITLE
Style updates for terminal look

### DIFF
--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -64,7 +64,7 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
   };
 
   return (
-    <div className="w-1/3 flex flex-col border-l border-slate-700/50 bg-slate-900/80 backdrop-blur-sm">
+    <div className="w-1/3 flex flex-col border-l border-slate-700/50 bg-slate-900/80 backdrop-blur-sm font-mono">
       {/* Header */}
       <header className="p-4 border-b border-slate-700/50 flex-shrink-0">
         <div className="flex items-center justify-center space-x-3">
@@ -105,7 +105,7 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
           
           return (
             <div key={index} className={`flex ${isUser ? 'justify-end' : 'justify-start'}`}>
-              <div 
+              <div
                 onClick={() => !isUser && onHistoryClick(item)}
                 className={`
                   max-w-[85%] group transition-all duration-200
@@ -114,18 +114,22 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
                 `}
               >
                 <div className={`
-                  p-4 rounded-lg shadow-lg
-                  ${isUser 
-                    ? 'bg-blue-600 text-white ml-4' 
-                    : 'bg-slate-700/80 hover:bg-slate-700 text-gray-100 mr-4'
+                  p-4
+                  ${isUser
+                    ? 'bg-gray-700 text-white ml-4'
+                    : 'bg-[#1e1e1e] text-gray-100 mr-4'
                   }
                 `}>
+                  <div className={`flex items-center text-xs text-gray-400 ${isUser ? 'justify-end mb-2' : 'mb-2'}`}>
+                    <Clock className="w-3 h-3 mr-1" />
+                    {formatTime(item.timestamp)}
+                  </div>
                   {/* Small tab dot indicator for AI responses */}
                   {!isUser && dotInfo && (
                     <span
                       className={`absolute top-2 right-2 flex items-center group`}
                     >
-                      <span 
+                      <span
                         className={`w-2 h-2 rounded-full ${dotInfo.color} border border-white/60 shadow`}
                         title={dotInfo.label}
                       />
@@ -147,11 +151,6 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
                     </p>
                   </div>
                 </div>
-                
-                <div className={`flex items-center mt-1 text-xs text-gray-500 ${isUser ? 'justify-end mr-4' : 'ml-4'}`}>
-                  <Clock className="w-3 h-3 mr-1" />
-                  {formatTime(item.timestamp)}
-                </div>
               </div>
             </div>
           );
@@ -159,7 +158,7 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
         
         {isLoading && (
           <div className="flex justify-start">
-            <div className="bg-slate-700/80 p-4 rounded-lg mr-4 max-w-[85%]">
+            <div className="bg-[#1e1e1e] p-4 mr-4 max-w-[85%]">
               <div className="flex items-center space-x-2">
                 <Bot className="w-4 h-4 text-blue-400" />
                 <div className="flex space-x-1">
@@ -197,14 +196,14 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
         
         {/* Input */}
         <div className="flex items-end space-x-2">
-          <div className="flex-1 bg-slate-800/50 border border-slate-600/50 rounded-lg focus-within:border-blue-500/50 transition-colors">
+          <div className="flex-1 bg-[#1e1e1e] border border-slate-700 focus-within:border-blue-500 transition-colors">
             <textarea
               value={userInput}
               onChange={(e) => setUserInput(e.target.value)}
               onKeyDown={handleKeyDown}
               disabled={isLoading}
               rows={3}
-              className="w-full bg-transparent text-white placeholder-gray-400 p-3 focus:outline-none resize-none scrollbar-thin scrollbar-thumb-slate-600 scrollbar-track-transparent"
+              className="w-full bg-transparent text-white placeholder-gray-400 p-3 focus:outline-none resize-none scrollbar-thin scrollbar-thumb-slate-600 scrollbar-track-transparent font-mono"
               placeholder="Ask about the analysis..."
             />
           </div>


### PR DESCRIPTION
## Summary
- use monospaced font in chat panel
- refactor message layout to show timestamp header
- update message background colours
- restyle input box for a terminal feel

## Testing
- `npm run lint` *(fails: Parsing error and unused variables)*

------
https://chatgpt.com/codex/tasks/task_b_688905f66764832888cd268185241ac0