### PR TITLE
Refine visualization card styles

### DIFF
--- a/src/components/visualizations/COAComparison.tsx
+++ b/src/components/visualizations/COAComparison.tsx
@@ -42,7 +42,7 @@ export const COAComparison: React.FC<COAComparisonProps> = ({
           <div
             key={coa.id}
             className={`
-              relative bg-slate-900/60 border-2 rounded-lg p-4
+              relative border border-gray-600 bg-[#121212] p-4
               cursor-pointer
               ${getBorderColor(coa.id, coa.recommendationScore)}
             `}

--- a/src/components/visualizations/SHAPVisual.tsx
+++ b/src/components/visualizations/SHAPVisual.tsx
@@ -125,10 +125,7 @@ export const SHAPVisual: React.FC<SHAPVisualProps> = ({
                     style={{ width: `${(Math.abs(value) / maxAbsValue) * 100}%` }}
                     className={`
                       h-full transition-all duration-500 ease-out
-                      ${value > 0
-                        ? 'bg-gradient-to-r from-green-500 to-green-400'
-                        : 'bg-gradient-to-r from-red-500 to-red-400'
-                      }
+                      ${value > 0 ? 'bg-green-700' : 'bg-red-600'}
                     `}
                   />
                 </div>

--- a/src/components/visualizations/VisualCard.tsx
+++ b/src/components/visualizations/VisualCard.tsx
@@ -8,13 +8,7 @@ interface VisualCardProps {
 
 export const VisualCard: React.FC<VisualCardProps> = ({ title, children, className = '' }) => {
   return (
-    <div className={`
-      bg-slate-800/50 backdrop-blur-sm border border-slate-700/50 
-      rounded-xl p-6 shadow-lg hover:shadow-xl
-      transition-all duration-300 ease-in-out
-      hover:border-slate-600/50 hover:bg-slate-800/70
-      ${className}
-    `}>
+    <div className={`border border-gray-600 bg-[#121212] p-4 ${className}`}>
       {title && (
         <h3 className="text-lg font-semibold text-white mb-4 border-b border-slate-700/50 pb-2">
           {title}


### PR DESCRIPTION
## Summary
- simplify `VisualCard` styling with flat border and background
- update COA card look to match new style
- mute SHAP bar colors for a flatter appearance

## Testing
- `npm run lint` *(fails: 19 errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_688905fcecbc8328aa69ccbac48325a1