### PR TITLE
Improve layout styles and progress components

### DIFF
--- a/src/components/MainContent.tsx
+++ b/src/components/MainContent.tsx
@@ -82,31 +82,28 @@ export const MainContent: React.FC<MainContentProps> = ({
     }
   };
 
+  const confidenceBar = React.useMemo(() => {
+    if (!explanation.confidence) return null;
+    const filled = Math.round(explanation.confidence / 10);
+    const empty = 10 - filled;
+    const bar = '█'.repeat(filled) + '░'.repeat(empty);
+    return `${bar} ${explanation.confidence}%`;
+  }, [explanation.confidence]);
+
   return (
     <main className="flex-1 overflow-y-auto p-6 bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900">
-      <div className="max-w-7xl mx-auto">
-        <div className="mb-8">
+      <div className="max-w-7xl mx-auto space-y-8">
+        <div>
           <h2 className="text-3xl font-bold text-white mb-2 leading-tight">
             {explanation.response || "Select an analysis from the chat history"}
           </h2>
           {explanation.confidence && (
-            <div className="flex items-center space-x-3">
-              <span className="text-sm text-gray-400">Confidence Level:</span>
-              <div className="flex items-center bg-slate-800/50 rounded-full px-3 py-1">
-                <div className="w-16 bg-slate-700 rounded-full h-2 mr-2">
-                  <div 
-                    className="bg-gradient-to-r from-blue-500 to-green-500 h-2 rounded-full transition-all duration-500"
-                    style={{ width: `${explanation.confidence}%` }}
-                  />
-                </div>
-                <span className="text-sm font-semibold text-white">
-                  {explanation.confidence}%
-                </span>
-              </div>
-            </div>
+            <p className="text-sm text-gray-400 font-mono">
+              Confidence Level: <span className="text-white">{confidenceBar}</span>
+            </p>
           )}
         </div>
-        
+
         <div role="tabpanel" id={`${activeTab}-panel`} aria-labelledby={`${activeTab}-tab`}>
           {renderTabContent()}
         </div>

--- a/src/components/ScenarioPhases.tsx
+++ b/src/components/ScenarioPhases.tsx
@@ -16,22 +16,30 @@ export const ScenarioPhases: React.FC<ScenarioPhasesProps> = ({ phases }) => {
           Mission Timeline & Phases
         </h3>
       </div>
-      
+
+      {/* Horizontal progression bar with labels */}
+      <div className="mb-8 flex items-center justify-between">
+        {phases.map((phase, index) => (
+          <div key={index} className="flex flex-col items-center flex-1">
+            <div className="flex items-center w-full">
+              {index > 0 && <div className="flex-1 h-1 bg-slate-600" />}
+              <div className="w-3 h-3 bg-blue-500" />
+              {index < phases.length - 1 && <div className="flex-1 h-1 bg-slate-600" />}
+            </div>
+            <span className="mt-2 text-xs text-gray-300 whitespace-nowrap">
+              {phase.phase}
+            </span>
+          </div>
+        ))}
+      </div>
+
       <div className="space-y-6">
         {phases.map((phase, index) => (
           <div key={index} className="relative">
-            {/* Phase Header */}
-            <div className="flex items-center mb-4">
-              <div className="flex-shrink-0 w-8 h-8 bg-blue-600 rounded-full flex items-center justify-center text-white font-bold text-sm mr-4">
-                {index + 1}
-              </div>
-              <h4 className="text-lg font-semibold text-white">
-                {phase.phase}
-              </h4>
-            </div>
-            
-            {/* Actions List */}
-            <div className="ml-12 space-y-2">
+            <h4 className="text-lg font-semibold text-white mb-2">
+              {phase.phase}
+            </h4>
+            <div className="ml-4 space-y-2">
               {phase.actions.map((action, actionIndex) => {
                 const isXAIActivation = action.includes('XAI Panel');
                 return (
@@ -39,8 +47,8 @@ export const ScenarioPhases: React.FC<ScenarioPhasesProps> = ({ phases }) => {
                     key={actionIndex}
                     className={`
                       flex items-start p-3 rounded-lg transition-all duration-200
-                      ${isXAIActivation 
-                        ? 'bg-amber-500/20 border border-amber-500/50 text-amber-200' 
+                      ${isXAIActivation
+                        ? 'bg-amber-500/20 border border-amber-500/50 text-amber-200'
                         : 'bg-slate-800/50 hover:bg-slate-800/70 text-gray-300'
                       }
                     `}
@@ -59,11 +67,6 @@ export const ScenarioPhases: React.FC<ScenarioPhasesProps> = ({ phases }) => {
                 );
               })}
             </div>
-            
-            {/* Connector Line */}
-            {index < phases.length - 1 && (
-              <div className="absolute left-4 top-12 w-0.5 h-8 bg-slate-600"></div>
-            )}
           </div>
         ))}
       </div>

--- a/src/components/tabs/InsightTab.tsx
+++ b/src/components/tabs/InsightTab.tsx
@@ -20,7 +20,7 @@ export const InsightTab: React.FC<InsightTabProps> = ({
   onCOAInteraction
 }) => {
   return (
-    <div className="space-y-6 animate-fade-in">
+    <div className="space-y-8 animate-fade-in">
       <VisualCard>
         <div className="flex items-center mb-4">
           <Eye className="w-6 h-6 text-blue-400 mr-3" />

--- a/src/components/tabs/ProjectionTab.tsx
+++ b/src/components/tabs/ProjectionTab.tsx
@@ -16,7 +16,7 @@ export const ProjectionTab: React.FC<ProjectionTabProps> = ({
   onVisualizationClick
 }) => {
   return (
-    <div className="space-y-6 animate-fade-in">
+    <div className="space-y-8 animate-fade-in">
       <VisualCard>
         <div className="flex items-center mb-4">
           <Activity className="w-6 h-6 text-purple-400 mr-3" />

--- a/src/components/tabs/ReasoningTab.tsx
+++ b/src/components/tabs/ReasoningTab.tsx
@@ -17,7 +17,7 @@ export const ReasoningTab: React.FC<ReasoningTabProps> = ({
   onVisualizationClick
 }) => {
   return (
-    <div className="space-y-6 animate-fade-in">
+    <div className="space-y-8 animate-fade-in">
       {/* Put summary and SHAP side-by-side */}
       <div className="grid grid-cols-1 xl:grid-cols-2 gap-6">
         <VisualCard>


### PR DESCRIPTION
## Summary
- standardize spacing across main and tab sections
- add textual confidence bar in `MainContent`
- update scenario phases to horizontal bar style

## Testing
- `npm run lint` *(fails: Parsing error and unused vars)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6889060259608328aa99db1142eb8608